### PR TITLE
Add a pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2022 The PyPSA-Earth and Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Copied from https://github.com/PyPSA/pypsa-eur/pull/302/files
+
+exclude: "^LICENSES"
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-merge-conflict
+  - id: end-of-file-fixer
+  - id: fix-encoding-pragma
+  - id: mixed-line-ending
+#   - id: check-added-large-files
+#     args: ['--maxkb=2000']
+
+# Sort package imports alphabetically
+- repo: https://github.com/PyCQA/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
+    args: ["--profile", "black", "--filter-files"]
+
+# # Find common spelling mistakes in comments and docstrings
+# - repo: https://github.com/codespell-project/codespell
+#   rev: v2.2.1
+#   hooks:
+#   - id: codespell
+#     args: ['--ignore-regex="\b[A-Z]+\b"'] # Ignore capital case words, e.g. country codes
+#     types_or: [python, rst, markdown]
+#     files: ^(actions|doc)/
+
+# Formatting with "black" coding style
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+  # Format Python files
+  - id: black
+  # Format Jupyter Python notebooks
+  - id: black-jupyter
+
+# Do YAML formatting (before the linter checks it for misses)
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.6.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix, --indent, '2', --preserve-quotes]
+
+# Use yamllint to check for valid YAML files and list syntax errors
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.29.0
+  hooks:
+  - id: yamllint
+    args: [--format, parsable, -c=.yamllint]
+
+# Format Snakemake rule / workflow files
+- repo: https://github.com/snakemake/snakefmt
+  rev: v0.8.0
+  hooks:
+  - id: snakefmt
+
+# # Check for FSFE REUSE compliance (licensing)
+# - repo: https://github.com/fsfe/reuse-tool
+#   rev: v0.14.0
+#   hooks:
+#   - id: reuse


### PR DESCRIPTION
It would be great to have a pre-commit hook also in the documentation repository. A `.pre-commit-config.yaml` is copied from `pypsa-earth` repository